### PR TITLE
Improve README with logo and detailed overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,49 @@
+```
+ __      __   _   _          _     _      ____  _______ ______
+ \ \    / /__| |_| |__   ___| |__ (_)_ __| __ )|__   __|  ____|
+  \ \/\/ / _ \ __| '_ \ / _ \ '_ \| | '__|  _ \   | |  | |__   
+   \_/\_/  __/ |_| | | |  __/ |_) | | |  | |_) |  | |  |  __|  
+            \___|\__|_| |_|\___|_.__/|_|_|  |____/   |_|  |_____| 
+ 
+           Volxbibel Wiki -> RTF Export
+```
+
+The Volxbibel RTF Export is a small PHP application for converting pages
+from a MediaWiki installation into Rich Text Format files. It was initially
+created to generate printable versions of the collaborative "Volxbibel"
+Bible translation. The exporter logs in to the wiki, fetches the requested
+pages via the MediaWiki API, transforms the wiki markup into HTML using
+PEAR's Text_Wiki_Mediawiki parser and finally renders an RTF document
+with a lightweight RTF library.
+
+## Technologies
+- PHP (>=5)
+- [PEAR HTTP_Request](http://pear.php.net/package/HTTP_Request) for HTTP
+  communication with the wiki
+- [PEAR Text_Wiki_Mediawiki](http://pear.php.net/package/Text_Wiki_Mediawiki)
+  for converting wiki syntax to HTML
+- A simple PHP based RTF library located in `wikiexport/libs/rtf`
+
+## Project structure
+- `wikiexport` contains the PHP scripts, configuration files and the RTF
+  library used for the export.
+- `__old` holds early experiments and is kept for reference only.
+
+The configuration is done in `wikiexport/config/config.php`. Copy the
+`config.template.php` file and adjust the constants `WIKI_SERVER`,
+`WIKI_USER` and `WIKI_PASSWORD` so that the script can access your
+MediaWiki installation. Once configured, calling `index.php` will produce
+an RTF file containing the selected pages.
+
 ### How to use
 + Rename `/config/config.template.php` into `config.php`.
-+ Set the constant `WIKI_SERVER`, to the domain and path to your MediaWiki installation, with `http://` but no trailing `/`. 
++ Set the constant `WIKI_SERVER`, to the domain and path to your MediaWiki installation, with `http://` but no trailing `/`.
 + Set `WIKI_USER` and `WIKI_PASSWORD` for a wiki user which has the rights to export data from the MediaWiki.
 
 ### Requirements
 * PHP > 5
 
-PEAR Packages and all their dependencies, see `/config/bootstrap.php`: 
+PEAR Packages and all their dependencies, see `/config/bootstrap.php`:
 * HTTP_Request
 * Text_Wiki_Mediawiki
 


### PR DESCRIPTION
## Summary
- add ASCII logo for the exporter
- document project purpose and technologies
- keep existing instructions for configuration and usage

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867efdc1fe0832dbcaa491094e7b10f